### PR TITLE
Update runtime version from 48 to 50 and more

### DIFF
--- a/com.esrille.furiganapad.json
+++ b/com.esrille.furiganapad.json
@@ -1,13 +1,19 @@
 {
     "id" : "com.esrille.furiganapad",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "command" : "furiganapad",
     "finish-args" : [
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland"
+    ],
+    "cleanup": [
+        "/share/man"
+    ],
+    "cleanup-commands": [
+        "python3 -m compileall --invalidation-mode=unchecked-hash /app"
     ],
     "modules" : [
         {

--- a/python3-PyICU.json
+++ b/python3-PyICU.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/60/b8/1540a0a0cd74aa878749d442e19916df946e3b187c9965a991ddc77cc39c/PyICU-2.13.1.tar.gz",
-            "sha256": "d4919085eaa07da12bade8ee721e7bbf7ade0151ca0f82946a26c8f4b98cdceb"
+            "url": "https://files.pythonhosted.org/packages/b7/d5/354eb1bf84dcf4ab0bfa46f0620ecf68fe313bb082c26872ceb7a5021f94/pyicu-2.16.2.tar.gz",
+            "sha256": "006d51e24b5ec76df6ec2130f3dde269c51db8b8cfebb7d45a427dde0d10aa52"
         }
     ]
 }


### PR DESCRIPTION
- Update the runtime version to 50
- Update PyICU module
- Remove redundant man files
- Compile pyc files to improve the performance